### PR TITLE
Enable epel-release repository. This is required for pyhton-pip package

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -16,6 +16,11 @@
     state: installed
     enablerepo: gluu
 
+- name: Enable epel-release repository
+  yum:
+    name: epel-release
+    state: installed
+
 - name: Install global python requirements for pip
   yum:
     name: "{{item}}"
@@ -32,4 +37,3 @@
 
 - name: Start Gluu service
   command: /sbin/gluu-serverd-{{ gluu_version }} start
-


### PR DESCRIPTION
on CentOS7. Installation otherwise fails due to pyhton-pip cannot befound.